### PR TITLE
Fix #13: AI Transcription Tool

### DIFF
--- a/guides/20260905_guide_ai_transcription_with_sapat.md
+++ b/guides/20260905_guide_ai_transcription_with_sapat.md
@@ -1,0 +1,324 @@
+---
+title: "AI Transcription with Sapat: OpenAI, Groq, Whisper"
+description: "A practical, long-form guide for building reliable AI transcription pipelines using Sapat — covers provider choices (OpenAI, Groq, cloud STT providers, local Whisper), audio preprocessing (ffmpeg), diarization, batching, cost controls and troubleshooting."
+date: 2026-09-05
+author: "Automated Contributor"
+tags: ['transcription','sapat','whisper','openai','groq','ffmpeg','daytona']
+---
+
+# AI Transcription with Sapat: OpenAI, Groq, Whisper
+
+## Introduction
+
+This guide is for AI engineers and infra-focused developers who need a robust,
+reproducible transcription pipeline. We'll cover practical patterns you can use
+with Sapat (the CLI/transcription helper referenced in the issue), describe
+how to configure and compare different provider backends (OpenAI, Groq, cloud
+STT vendors, and local Whisper), and provide detailed operational guidance on
+audio preprocessing, batching, speaker diarization, cost control and
+troubleshooting.
+
+Note: this guide focuses on engineering patterns and reproducible steps that
+are safe to follow in a Daytona workspace. Where I show placeholder CLI
+examples, treat them as patterns — check the Sapat README or your project's
+CLI reference for exact flags and argument names.
+
+## TL;DR
+
+- Preprocess audio with ffmpeg: convert to mono, 16 kHz, 16-bit PCM; normalize
+  loudness for best results.
+- Choose a provider by balancing cost, latency, and accuracy: OpenAI (Whisper
+  family), Groq, AssemblyAI/Deepgram/Google/Azure for cloud STT, or local
+  Whisper / whisper.cpp for offline/low-cost workloads.
+- Use VAD-based chunking and short segments (30–120s) for better accuracy and
+  stable latency; re-join text with timestamps later.
+- Add lightweight postprocessing: punctuation and casing (LLM or rules),
+  speaker diarization (pyannote, webrtcvad+clustering), and domain language
+  models for names / entities.
+- Monitor cost and quality: sample transcripts for WER, track request counts
+  and token usage, and use retries/backoff for transient failures.
+
+## Preparations
+
+Prerequisites
+
+- Git, Docker (optional) and a reproducible development workspace (Daytona
+  devcontainer recommended).
+- ffmpeg installed on the host or in your container (ffmpeg 4.x+).
+- API keys for chosen cloud providers (stored in environment variables or a
+  secrets store). Never check secrets into git.
+- Python or Node if you plan to run helper scripts (examples below use bash +
+  lightweight Python snippets).
+
+Example environment variables (placeholders only):
+
+```
+# Do NOT commit real keys. Keep them in secrets manager or .env that is gitignored.
+OPENAI_API_KEY=YOUR_OPENAI_KEY
+GROQ_API_KEY=YOUR_GROQ_KEY
+DEEPGRAM_API_KEY=YOUR_DEEPGRAM_KEY
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/google-service-account.json
+```
+
+Install tools
+
+- ffmpeg: follow your OS package manager or use a container image.
+- Sapat: follow the project's README. When installed it usually exposes a
+  simple CLI (for example: sapat transcribe ...). Use the README to confirm
+  exact CLI names and flags.
+
+## Audio preprocessing with ffmpeg (practical commands)
+
+Good transcription quality starts with clean, correctly sampled audio. The
+most common audio target for ASR is 16 kHz, 16-bit PCM, mono.
+
+1) Quick conversion to canonical WAV:
+
+```bash
+# Convert any input to mono 16kHz 16-bit PCM WAV
+ffmpeg -hide_banner -y -i input.mp4 \
+  -vn -ac 1 -ar 16000 -sample_fmt s16 output.wav
+```
+
+2) Loudness normalization (useful for noisy / variable inputs):
+
+```bash
+# Two-pass EBU loudness normalization (recommended for podcasts / variable audio)
+ffmpeg -y -i input.mp4 -vn -af loudnorm=I=-16:TP=-1.5:LRA=11 -ar 16000 -ac 1 -sample_fmt s16 output_norm.wav
+```
+
+3) Trim silence and drop extremely short segments (optional):
+
+```bash
+# Trim silence at start/end using ffmpeg's silenceremove
+ffmpeg -y -i output_norm.wav -af silenceremove=stop_periods=-1:stop_duration=1:stop_threshold=-50dB trimmed.wav
+```
+
+Why these steps matter:
+
+- Resampling to 16 kHz matches the training conditions of many Whisper models
+  and yields a smaller payload to cloud APIs (reducing cost).
+- Mono avoids channel duplication and keeps speaker mixing consistent.
+- Loudness normalization reduces clipping and helps models with variable
+  volume.
+
+## Chunking & VAD
+
+Long files should be chunked before sending to an API. Chunking reduces token
+limits, lowers request latencies, and helps with partial retries.
+
+Common strategy:
+
+- Use a VAD (webrtcvad, pyannote) to find speech regions.
+- Merge adjacent speech regions up to a target segment length (30–120s).
+- Export segments with consistent timestamps and pass them for transcription.
+
+A small bash pattern using ffmpeg to split every N seconds (naive):
+
+```bash
+# naive 60s chunker
+ffmpeg -i trimmed.wav -f segment -segment_time 60 -c copy out%03d.wav
+```
+
+Prefer speech-aware chunking for better natural boundaries.
+
+## Provider choices: tradeoffs and suggestions
+
+OpenAI
+- Pros: strong transcription quality (Whisper-based models), good multi-language support; well-maintained API; easy to combine with LLMs for postprocessing.
+- Cons: cost can be non-trivial at scale; latency depends on model and region.
+
+Groq
+- Pros: specialized inference hardware and low-latency inference (vendor
+  dependent). Good for CPU/accelerator-driven inference at scale.
+- Cons: vendor-specific SDKs and pricing — check Groq docs for the latest
+  endpoints and supported model names.
+
+Cloud STT Providers (Google, Azure Speech, AssemblyAI, Deepgram, Speechmatics)
+- Pros: enterprise-grade features (diarization, punctuation, telephony
+  models), managed scaling, good tooling for streaming.
+- Cons: APIs differ, costs and accuracy vary by language and domain.
+
+Local Whisper (open-source / whisper.cpp)
+- Pros: full offline control, no per-request cost, modifiable for domain
+  adaptation, runs on GPU/CPU (with quantized builds).
+- Cons: requires compute resources, slower on CPU; large models need GPU.
+
+Which to pick?
+- For accuracy-first, one-off or high-value transcripts: OpenAI large or cloud
+  provider's best accuracy model.
+- For streaming / low-latency, look at providers that support streaming APIs or
+  Groq-like hardware-backed inference.
+- For low-cost at scale and offline compliance, use local Whisper + batching.
+
+## Sapat: integrating providers (patterns, not exact API calls)
+
+Sapat aims to be a thin orchestration layer around ASR backends. Typical
+integration points you will use:
+
+- CLI: a command like `sapat transcribe` (check the project README for exact
+  CLI) which accepts one or more input files and a provider selection.
+- Configuration: provider keys are pulled from environment variables or a
+  config file. Follow _secure_ patterns; e.g. use secrets managers or
+  gitignored .env files.
+- Output: Sapat typically writes timestamps, raw transcript text, and a
+  structured JSON with segment-level confidence. Use that payload to run
+  postprocessing and storage.
+
+Example pattern (placeholder):
+
+```bash
+# Pattern only — confirm CLI with Sapat README
+sapat transcribe ./input/episode.mp4 \
+  --provider openai \
+  --model whisper-large \
+  --out ./transcripts/episode.json
+```
+
+If you need to add another cloud provider adapter, follow these engineering
+principles:
+
+- Keep provider adapters thin: one function to send bytes and metadata, one to
+  parse the provider response into a canonical internal transcript JSON.
+- Normalize timestamps and confidence scores across providers.
+- Avoid leaking provider-specific fields to the rest of the pipeline; keep an
+  internal canonical shape.
+- Implement retry logic (exponential backoff) on transient 5xx/429 errors and
+  a circuit breaker for repeated failures.
+
+## Postprocessing: punctuation, casing, entity handling
+
+Most ASR outputs are raw text: no punctuation, inconsistent casing, and poor
+entity formatting. Common postprocessing steps:
+
+- Punctuation & casing: Use a small LLM or an NLU model to re-punctuate and
+  apply sentence-case. For deterministic use, a lightweight transformer model
+  fine-tuned for punctuation can be used.
+- Numeric normalization:  convert spoken numbers to digits only when needed
+  (e.g., "one hundred twenty" -> "120").
+- NER & canonicalization: run a named-entity recognizer to tag and canonicalize
+  names and proper nouns (use domain-specific glossaries to fix brand names).
+- Timestamps: stitch segment-level text back together using segment offsets;
+  adjust boundaries if a sentence spans two segments.
+
+Example two-pass flow:
+
+1. First pass: ASR produces raw segments + timestamps.
+2. Group segments into sentences using a punctuation model.
+3. Apply diarization results (speaker labels) and attach them to sentences.
+4. Run final quality checks and export SRT, VTT, and plain text formats.
+
+## Speaker diarization and speaker attribution
+
+- Lightweight approach: run a diarization model (pyannote) on the preprocessed
+  audio to produce speaker segments; map those timestamps onto ASR segments.
+- Practical tips: diarization models are sensitive to sample rate and channel.
+  Use the same preprocessed WAV you passed to ASR for diarization.
+- If perfect speaker labels are required (e.g. named speakers), provide short
+  enrollment samples per speaker and use speaker embedding matching.
+
+## Scaling, batching and reliability
+
+- Batch requests for large numbers of short files to reduce overhead.
+- For very large single files, use chunking + out-of-order parallel requests
+  and re-assemble the result deterministically.
+- Implement idempotency: tag requests with job IDs so retries won't duplicate
+  outputs.
+- Observability: emit metrics for requests/success/failure, average latency,
+  and API cost estimates. Track sample WER over time.
+
+## Cost and latency controls
+
+- Use cheaper / smaller models for drafts and quick previews; use higher-cost
+  models only for final transcripts.
+- Cache results of repeated transcriptions of the same audio (checksum-based).
+- Sample transcripts for human review instead of reviewing all transcripts.
+
+## Whisper deep dive: model sizes and implications
+
+Open-source Whisper model family: tiny, base, small, medium, large.
+
+- Tiny/Base: very fast, lower accuracy — good for quick previews.
+- Small/Medium: solid balance of speed and accuracy.
+- Large: best accuracy, much higher GPU memory and latency requirements.
+
+Performance considerations:
+
+- GPU inference gives big speedups; quantized whisper.cpp builds let you run
+  reasonably fast on CPU for small-ish models.
+- For multi-language audio, use language detection first or run a multi-lingual
+  model; Whisper models already include language detection heuristics.
+
+## Evaluation: WER, CER and sampling
+
+- If you have ground-truth references, compute WER (Word Error Rate) using
+  jiwer or similar libraries. Use a holdout sample to detect regressions.
+- Build a tiny test-suite of 100–200 minutes of representative audio across
+  environments (phones, mics, podcasts) to detect distribution shifts.
+
+## Common issues & troubleshooting
+
+Problem: Transcript is full of errors / mumbled words
+- Check audio quality: SNR, clipping, or low bitrate. Re-run with loudness
+  normalization and noise reduction.
+
+Problem: Model fails on long files or times out
+- Chunk audio into smaller segments; make requests in parallel with controlled
+  concurrency.
+
+Problem: Speaker labels misaligned
+- Ensure diarization and ASR use the same preprocessed audio and timestamps.
+- Increase diarization model capacity or provide speaker enrollment samples.
+
+Problem: High cost
+- Use smaller models for draft transcripts.
+- Cache results and only re-run changed files.
+
+## Example batch script (pattern)
+
+```bash
+# Naive pattern — replace sapat CLI flags with the ones from the Sapat README
+mkdir -p transcripts
+for f in ./media/*.mp4; do
+  base=$(basename "$f" .mp4)
+  ffmpeg -hide_banner -y -i "$f" -vn -ac 1 -ar 16000 -sample_fmt s16 "tmp/${base}.wav"
+  # Call the Sapat CLI (placeholder) — check the README for exact args
+  sapat transcribe "tmp/${base}.wav" --provider openai --model whisper-medium --out "transcripts/${base}.json" || echo "failed: $f" >> failed.txt
+done
+```
+
+## Putting it in a Daytona workspace
+
+- Create a devcontainer that includes ffmpeg and Sapat (or build Sapat inside
+  the container). Commit your reproducible devcontainer configuration so the
+  pipeline runs identically for all team members.
+- Store secret injection configs in your Daytona workspace runtime, not in
+  git. Use a `.env` or secret manager integration with Daytona.
+
+## Conclusion
+
+This guide covered a production-minded approach to using Sapat in an
+AI transcription pipeline. The core takeaways:
+
+- Preprocess audio consistently (16 kHz, mono, normalized loudness).
+- Choose the right provider for your latency, cost and accuracy needs.
+- Chunk and pipeline segments for parallel, reliable processing.
+- Postprocess with punctuation/NER/diarization and add human review where
+  necessary.
+
+If you plan to contribute provider adapters or improvements to Sapat, keep
+adapters small, provide canonical output shapes, and add robust retry and
+metrics logic.
+
+## References & further reading
+
+- Sapat repository (refer to the project's README for exact CLI and adapter
+  instructions): https://github.com/nkkko/sapat
+- OpenAI (Whisper / transcription models)
+- Groq hardware & inference docs
+- ffmpeg documentation and the `loudnorm` filter
+- pyannote.audio (speaker diarization)
+- whisper.cpp (local, quantized Whisper inference)
+
+
+<!-- Note: the CLI examples above use placeholder flags to show patterns. Confirm exact CLI names and flags in the Sapat README before copy/pasting into production. -->


### PR DESCRIPTION
Added a new comprehensive guide file guides/20260905_guide_ai_transcription_with_sapat.md covering Sapat-based transcription workflows. The guide includes: detailed ffmpeg preprocessing commands, chunking and VAD strategies, provider tradeoffs (OpenAI, Groq, cloud STT, local Whisper), Sapat integration patterns, postprocessing (punctuation, NER), diarization, scaling, cost controls, Whisper deep dive, evaluation metrics, troubleshooting, and Daytona workspace tips. File created and ready for PR. /claim #13

PR Title suggestion: "/claim #13: AI Transcription with Sapat — OpenAI, Groq, Whisper guide"

PR Body suggestion:
- Closes #13
- Summary: Add long-form Daytona-style guide documenting how to use Sapat for transcription, provider tradeoffs, ffmpeg preprocessing, Whisper details, diarization, batching, cost/ops guidance, and Daytona workspace recommendations.
- Verification: New markdown added at guides/20260905_guide_ai_transcription_with_sapat.md. Run npx markdownlint to lint. (Commands executed: created file in repo.)

Resolvable: true

Closes #13

/claim #13